### PR TITLE
Added support for dataTypes sending once per assetName + typeID

### DIFF
--- a/C/common/include/omf.h
+++ b/C/common/include/omf.h
@@ -11,6 +11,7 @@
  */
 #include <string>
 #include <vector>
+#include <map>
 #include <reading.h>
 #include <http_sender.h>
 
@@ -26,10 +27,10 @@ class OMF
         public:
 		/**
 		 * Constructor:
-		 * pass server URL, OMF_type_id and producerToken.
+		 * pass server URL path, OMF_type_id and producerToken.
 		 */
 		OMF(HttpSender& sender,
-                    const std::string& url,
+                    const std::string& path,
 		    const std::string& typeId,
 		    const std::string& producerToken);
 
@@ -37,16 +38,22 @@ class OMF
 		 * Send data to PI Server passing a vector of readings.
 		 *
 		 * Data sending is composed by a few phases
-		 * handled by private methods:
+		 * handled by private methods.
+		 *
+		 * Note: DataTypes are sent only once by using
+		 * an in memory key map, being the key = assetName + typeId.
+		 * Passing false to skipSentDataTypes changes the logic.
 		 *
 		 * Returns the number of processed readings.
 		 */
 
 		// Method with vector of readings
-		uint32_t sendToServer(const std::vector<Reading>& readings);
+		uint32_t sendToServer(const std::vector<Reading>& readings,
+				      bool skipSentDataTypes = true);
 
 		// Method with vector of reading pointers
-		uint32_t sendToServer(const std::vector<Reading *> readings);
+		uint32_t sendToServer(const std::vector<Reading *> readings,
+				      bool skipSentDataTypes = true);
 
 		// Destructor
 		~OMF();
@@ -82,13 +89,21 @@ class OMF
 		void setAssetTypeTag(const std::string& assetName,
 				     const std::string& tagName,
 				     std::string& data) const;
-		// Send or caches OMF data types
-		int handleTypes(const Reading& row) const;
+		// Send OMF data types
+		int handleDataTypes(const Reading& row) const;
+
+		// Get saved dataType
+		bool getCreatedTypes(std::string& assetName);
+
+		// Set saved dataType
+		bool setCreatedTypes(std::string& assetName);
 
         private:
-		const std::string	m_serverURL;
-		const std::string	m_tokenId;
-		const std::string	m_producerToken;
+		const std::string		m_path;
+		const std::string		m_typeId;
+		const std::string		m_producerToken;
+		std::map<std::string, bool>	m_createdTypes;
+
 		// Vector with OMF_TYPES
 		const std::vector<std::string> omfTypes = { OMF_TYPE_STRING,
 							    OMF_TYPE_INTEGER,

--- a/C/services/north/omf_demo.cpp
+++ b/C/services/north/omf_demo.cpp
@@ -49,16 +49,34 @@ int main(void)
 	// Add it to the vector
 	readings.push_back(office);
 
-	SimpleHttps sender("192.168.0.132:5460");
+	// Add new readings
+	val = 876;
+	value = DatapointValue(val);
+	readings.push_back(Reading("home", new Datapoint("power", value)));
 
-	// Instantiate OMF Class with URL, OMF_TYTPE_ID and producerToken
-	OMF omfReadings = OMF(sender, "https://192.168.0.132:5460/ingress/messages", "8008", "omf_translator_8008");
+	fVal = 32.7;
+        value = DatapointValue(fVal);
+	readings.push_back(Reading("box", new Datapoint("temp", value)));
+
+	// Instantiate an HTTPS handler for "Hostname : port"
+	SimpleHttps sender("192.168.1.157:5460");
+
+	// Instantiate the OMF Class with URL path, OMF_TYTPE_ID and producerToken
+	OMF omfReadings = OMF(sender, "/ingress/messages", "8421", "omf_translator_8421");
+
+	/**
+	 * We can pass the auth token to the new version of PI server connector relay	
+	 * OMF omfReadings = OMF(sender, "/ingress/messages", "9221",
+	 *			 "uid=UUID&sig=BASE64_SIG");
+	 */
 
 	/**
 	 * Send the readings vector to PI Server
+	 * pass false if we want to send data types for each reading.
 	 */
 
 	cerr << "Sent readings data: " << omfReadings.sendToServer(readings) << endl;
+	//cerr << "Sent readings data: " << omfReadings.sendToServer(readings, false) << endl;
 
 	return 0;
 }


### PR DESCRIPTION
Added support for dataTypes sending once per assetName + typeID


Currently some messages are printed to stderr:

dataTypes for key [home8421] have been sent.
dataTypes for key [box8421] have been sent.
dataTypes for key [office8421] have been sent.
dataTypes for key [home8421] have been sent.
dataTypes for key [box8421] have been sent.
Sent readings data: 5


DataTypes skipping can be disabled passing false to sendToServer()