### PR TITLE
FOGL-1215: in case of transmission error set m_lastError to true

### DIFF
--- a/C/common/include/http_sender.h
+++ b/C/common/include/http_sender.h
@@ -26,7 +26,7 @@ class HttpSender
 		HttpSender();
 
 		// Destructor
-		~HttpSender();
+		virtual ~HttpSender();
 
 		/**
 		 * HTTP(S) request: pass method and path, HTTP headers and POST/PUT payload.

--- a/C/common/include/omf.h
+++ b/C/common/include/omf.h
@@ -110,6 +110,7 @@ class OMF
 							    OMF_TYPE_FLOAT };
 		// HTTP Sender interface
 		HttpSender&		m_sender;
+		bool			m_lastError;
 };
 
 /**

--- a/C/common/simple_https.cpp
+++ b/C/common/simple_https.cpp
@@ -64,6 +64,7 @@ int SimpleHttps::sendRequest(const string& method,
 	{
 		auto res = m_sender->request(method, path, payload, header);
 		retCode = res->status_code;
+		//cerr << "Server reply: " << res->content.string() << endl;
 	} catch (exception& ex) {
 		cerr << "Failed to send data: " << ex.what() << endl;
 		return 0;


### PR DESCRIPTION
If m_lastError is true data types will be sent.

It's set back to false after first successfull data sending.

This prevents PI server not accepting reading data after a server restart or PI connector relay restart